### PR TITLE
Load new School Hall asset

### DIFF
--- a/main.js
+++ b/main.js
@@ -1556,7 +1556,8 @@ const bunnies = createBunnies();
 const sheep = spawnSheep();
 // Function to load and place the school hall
 function loadSchoolHall() {
-    const schoolHallUrl = "Public/Models/2School_Hall.glb";
+    // Updated to load the new School Hall asset
+    const schoolHallUrl = "Public/Models/School_Hall.glb";
     // Ensure the loader uses the DRACO decoder for this asset
     gltfLoader.setDRACOLoader(dracoLoader);
     gltfLoader.load(schoolHallUrl, (gltf) => {


### PR DESCRIPTION
## Summary
- load the new `School_Hall.glb` instead of the old placeholder

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845b607790883329aa2fd112b1db056